### PR TITLE
Simplified airborne/ground status API

### DIFF
--- a/src/main/java/de/serosystems/lib1090/msgs/modes/AllCallReply.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/modes/AllCallReply.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
  * Decoder for Mode S all-call replies
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
+@SuppressWarnings("unused")
 public class AllCallReply extends ModeSDownlinkMsg implements Serializable {
 
 	private static final long serialVersionUID = 2459589933570219472L;
@@ -87,21 +88,16 @@ public class AllCallReply extends ModeSDownlinkMsg implements Serializable {
 	}
 
 	/**
-	 * @return whether capabilities indicate that aircraft is on the ground.
-	 * Note that returning false does not indicate that the aircraft is airborne as status might be unknown!
-	 * See also {@link #isAirborne()}.
+	 * Whether capabilities indicate that aircraft is airborne.
+	 * @return true if airborne, false if on ground or null if ground status is unknown
 	 */
-	public boolean isOnGround() {
-		return capabilities == 4;
-	}
-
-	/**
-	 * @return whether capabilities indicate that aircraft is airborne.
-	 * Note that returning false does not indicate that the aircraft is on ground as status might be unknown!
-	 * See also {@link #isOnGround()}.
-	 */
-	public boolean isAirborne() {
-		return capabilities == 5;
+	public Boolean isAirborne() {
+		if (capabilities == 5) {
+			return true;
+		} else if (capabilities == 4) {
+			return false;
+		}
+		return null;
 	}
 
 

--- a/src/main/java/de/serosystems/lib1090/msgs/modes/AltitudeReply.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/modes/AltitudeReply.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
  * Decoder for Mode S surveillance altitude replies (DF 4)
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
+@SuppressWarnings("unused")
 public class AltitudeReply extends ModeSDownlinkMsg implements Serializable {
 
 	private static final long serialVersionUID = 190338580932294046L;
@@ -94,7 +95,7 @@ public class AltitudeReply extends ModeSDownlinkMsg implements Serializable {
 	 * </ul>
 	 * @see #hasAlert()
 	 * @see #hasSPI()
-	 * @see #isOnGround()
+	 * @see #isAirborne()
 	 */
 	public byte getFlightStatus() {
 		return flight_status;
@@ -115,21 +116,16 @@ public class AltitudeReply extends ModeSDownlinkMsg implements Serializable {
 	}
 
 	/**
-	 * @return whether flight status indicates that aircraft is on the ground.
-	 * For flight status &gt;= 4, this flag is unknown. Thus, a return value of false
-	 * does not indicate that the aircraft is airborne! See also {@link #isAirborne()}.
+	 * Whether flight status indicates that the aircraft is airborne.
+	 * @return true if airborne, false if on ground or null if ground status is unknown
 	 */
-	public boolean isOnGround() {
-		return flight_status==1 || flight_status==3;
-	}
-
-	/**
-	 * @return whether flight status indicates that aircraft is airborne.
-	 * For flight status &gt;= 4, this flag is unknown. Thus, a return value of false
-	 * does not indicate that the aircraft is on ground! See also {@link #isOnGround()} .
-	 */
-	public boolean isAirborne() {
-		return flight_status == 0 || flight_status == 2;
+	public Boolean isAirborne() {
+		if (flight_status == 0 || flight_status == 2) {
+			return true;
+		} else if (flight_status == 1 || flight_status == 3) {
+			return false;
+		}
+		return null;
 	}
 
 	/**

--- a/src/main/java/de/serosystems/lib1090/msgs/modes/CommBAltitudeReply.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/modes/CommBAltitudeReply.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
  * Decoder for Mode S surveillance altitude replies with Comm-B message (DF 20)
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
+@SuppressWarnings("unused")
 public class CommBAltitudeReply extends ModeSDownlinkMsg implements Serializable {
 
 	private static final long serialVersionUID = -7022055256214864570L;
@@ -100,7 +101,7 @@ public class CommBAltitudeReply extends ModeSDownlinkMsg implements Serializable
 	 * </ul>
 	 * @see #hasAlert()
 	 * @see #hasSPI()
-	 * @see #isOnGround()
+	 * @see #isAirborne()
 	 */
 	public byte getFlightStatus() {
 		return flight_status;
@@ -121,21 +122,16 @@ public class CommBAltitudeReply extends ModeSDownlinkMsg implements Serializable
 	}
 
 	/**
-	 * @return whether flight status indicates that aircraft is on the ground.
-	 * For flight status &gt;= 4, this flag is unknown. Thus, a return value of false
-	 * does not indicate that the aircraft is airborne! See also {@link #isAirborne()}.
+	 * Whether flight status indicates that the aircraft is airborne.
+	 * @return true if airborne, false if on ground or null if ground status is unknown
 	 */
-	public boolean isOnGround() {
-		return flight_status==1 || flight_status==3;
-	}
-
-	/**
-	 * @return whether flight status indicates that aircraft is airborne.
-	 * For flight status &gt;= 4, this flag is unknown. Thus, a return value of false
-	 * does not indicate that the aircraft is on ground! See also {@link #isOnGround()} .
-	 */
-	public boolean isAirborne() {
-		return flight_status == 0 || flight_status == 2;
+	public Boolean isAirborne() {
+		if (flight_status == 0 || flight_status == 2) {
+			return true;
+		} else if (flight_status == 1 || flight_status == 3) {
+			return false;
+		}
+		return null;
 	}
 
 	/**

--- a/src/main/java/de/serosystems/lib1090/msgs/modes/CommBIdentifyReply.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/modes/CommBIdentifyReply.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
  * Decoder for Mode S identify replies with Comm-B message (DF 21)
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
+@SuppressWarnings("unused")
 public class CommBIdentifyReply extends ModeSDownlinkMsg implements Serializable {
 
 	private static final long serialVersionUID = -1623942073259152603L;
@@ -100,7 +101,7 @@ public class CommBIdentifyReply extends ModeSDownlinkMsg implements Serializable
 	 * </ul>
 	 * @see #hasAlert()
 	 * @see #hasSPI()
-	 * @see #isOnGround()
+	 * @see #isAirborne()
 	 */
 	public byte getFlightStatus() {
 		return flight_status;
@@ -121,21 +122,16 @@ public class CommBIdentifyReply extends ModeSDownlinkMsg implements Serializable
 	}
 
 	/**
-	 * @return whether flight status indicates that aircraft is on the ground.
-	 * For flight status &gt;= 4, this flag is unknown. Thus, a return value of false
-	 * does not indicate that the aircraft is airborne! See also {@link #isAirborne()}.
+	 * Whether flight status indicates that the aircraft is airborne.
+	 * @return true if airborne, false if on ground or null if ground status is unknown
 	 */
-	public boolean isOnGround() {
-		return flight_status==1 || flight_status==3;
-	}
-
-	/**
-	 * @return whether flight status indicates that aircraft is airborne.
-	 * For flight status &gt;= 4, this flag is unknown. Thus, a return value of false
-	 * does not indicate that the aircraft is on ground! See also {@link #isOnGround()} .
-	 */
-	public boolean isAirborne() {
-		return flight_status == 0 || flight_status == 2;
+	public Boolean isAirborne() {
+		if (flight_status == 0 || flight_status == 2) {
+			return true;
+		} else if (flight_status == 1 || flight_status == 3) {
+			return false;
+		}
+		return null;
 	}
 
 	/**

--- a/src/main/java/de/serosystems/lib1090/msgs/modes/CommDExtendedLengthMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/modes/CommDExtendedLengthMsg.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
  * Decoder for Mode S surveillance Extended Length Messages (Comm-D ELM) (DF 24)
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
+@SuppressWarnings("unused")
 public class CommDExtendedLengthMsg extends ModeSDownlinkMsg implements Serializable {
 
 	private static final long serialVersionUID = 8539282448043078992L;

--- a/src/main/java/de/serosystems/lib1090/msgs/modes/IdentifyReply.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/modes/IdentifyReply.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
  * Decoder for Mode S surveillance identify replies (DF 5)
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
+@SuppressWarnings("unused")
 public class IdentifyReply extends ModeSDownlinkMsg implements Serializable {
 
 	private static final long serialVersionUID = -724671008366358621L;
@@ -94,7 +95,7 @@ public class IdentifyReply extends ModeSDownlinkMsg implements Serializable {
 	 * </ul>
 	 * @see #hasAlert()
 	 * @see #hasSPI()
-	 * @see #isOnGround()
+	 * @see #isAirborne()
 	 */
 	public byte getFlightStatus() {
 		return flight_status;
@@ -115,21 +116,16 @@ public class IdentifyReply extends ModeSDownlinkMsg implements Serializable {
 	}
 
 	/**
-	 * @return whether flight status indicates that aircraft is on the ground.
-	 * For flight status &gt;= 4, this flag is unknown. Thus, a return value of false
-	 * does not indicate that the aircraft is airborne! See also {@link #isAirborne()}.
+	 * Whether flight status indicates that the aircraft is airborne.
+	 * @return true if airborne, false if on ground or null if ground status is unknown
 	 */
-	public boolean isOnGround() {
-		return flight_status==1 || flight_status==3;
-	}
-
-	/**
-	 * @return whether flight status indicates that aircraft is airborne.
-	 * For flight status &gt;= 4, this flag is unknown. Thus, a return value of false
-	 * does not indicate that the aircraft is on ground! See also {@link #isOnGround()} .
-	 */
-	public boolean isAirborne() {
-		return flight_status == 0 || flight_status == 2;
+	public Boolean isAirborne() {
+		if (flight_status == 0 || flight_status == 2) {
+			return true;
+		} else if (flight_status == 1 || flight_status == 3) {
+			return false;
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
instead of separate `isOnGround()` and `isAirborne()` methods,
have a single method `isAirborne()` which returns `null` when
the ground status is unknown.

This is a breaking API change.

Affected messages are:
- AllCallReply
- AltitudeReply
- CommBAltitudeReply
- IdentifyReply
- CommBIdentifyReply