### PR TITLE
Performance improvement: int to hex conversion

### DIFF
--- a/src/main/java/de/serosystems/lib1090/Tools.java
+++ b/src/main/java/de/serosystems/lib1090/Tools.java
@@ -59,6 +59,27 @@ public class Tools {
 	}
 
 	/**
+	 * Converts an integer in a hex string ensuring a minimum number of digits
+	 * @param input value to be converted
+	 * @param minDigits minimum number of digits the result shall contain
+	 * @return hex representation of input integer
+	 */
+	public static String toHexString(int input, int minDigits) {
+		StringBuilder hex = new StringBuilder();
+		while (input > 0) {
+			int digit = input % 16;
+			hex.insert(0, hexDigits[digit]);
+			input = input / 16;
+		}
+		// ensures leading zeros based on min digits
+		while (hex.length() < minDigits) {
+			hex.insert(0, "0");
+		}
+
+		return hex.toString();
+	}
+
+	/**
 	 * Converts a hex string to an array of bytes.<br>
 	 * Source: https://stackoverflow.com/a/140861/3485023
 	 * @param str the hex string to convert

--- a/src/main/java/de/serosystems/lib1090/msgs/ModeSDownlinkMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/ModeSDownlinkMsg.java
@@ -148,7 +148,7 @@ public class ModeSDownlinkMsg implements Serializable {
 		 * @return address as 6 digit hex string
 		 */
 		public String getHexAddress() {
-			return String.format("%06x", address);
+			return Tools.toHexString(address, 6);
 		}
 
 		@Override


### PR DESCRIPTION
After testing and benchmarking lib1090 for our use case we found that some performance is lost when creating the hex representation frequently. 
Replacing `String.format` with this method provided a notable performance improvement.

Our jmh benchmarks show that this method is around 8 times faster than `String.format` . 