### PR TITLE
Improve usability of QualifiedAddress

### DIFF
--- a/src/main/java/de/serosystems/lib1090/msgs/ModeSDownlinkMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/ModeSDownlinkMsg.java
@@ -131,6 +131,20 @@ public class ModeSDownlinkMsg implements Serializable {
 		private Type type;
 
 		/**
+		 * protected no-arg constructor e.g. internal usage or for serialization with Kryo
+		 **/
+		protected QualifiedAddress() { }
+
+		public QualifiedAddress(int address, Type type) {
+			this.address = address;
+			this.type = type;
+		}
+
+		public QualifiedAddress(String address, Type type) {
+			this(Integer.parseInt(address, 16), type);
+		}
+
+		/**
 		 * @return type of address (e.g. ICAO 24-bit)
 		 */
 		public Type getType() {


### PR DESCRIPTION
Since `QualifiedAddress` is publicly exposed by the `ModeSDownlinkMsg` it would be useful to improve its usability to allow its construction for further usage by the lib1090 users. 