### PR TITLE
Fix extended squitter check

### DIFF
--- a/src/main/java/de/serosystems/lib1090/msgs/modes/ExtendedSquitter.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/modes/ExtendedSquitter.java
@@ -67,7 +67,7 @@ public class ExtendedSquitter extends ModeSDownlinkMsg implements Serializable {
 		super(reply);
 		setType(subtype.EXTENDED_SQUITTER);
 
-		if (getDownlinkFormat() < 17 && getDownlinkFormat() > 19 ||
+		if (getDownlinkFormat() < 17 || getDownlinkFormat() > 19 ||
 				getDownlinkFormat() == 18 && (getFirstField() == 4 || getFirstField() == 7) ||
 				getDownlinkFormat() == 19 && getFirstField() > 0)
 			throw new BadFormatException("Message is not an extended squitter!");


### PR DESCRIPTION
The first line of the condition should exclude any downlink formats that are certainly not extended squitters.

However, `x < 17 && x > 19` is semantically equivalent to `false`, so the `if` condition was effectively reduced to the remaining 2 conditions on format 18 and 19.
Specifically, it let wrong formats pass.
