### PR TITLE
Fix surface position decoding

### DIFF
--- a/src/main/java/de/serosystems/lib1090/cpr/CompactPositionReporting.java
+++ b/src/main/java/de/serosystems/lib1090/cpr/CompactPositionReporting.java
@@ -64,8 +64,10 @@ public class CompactPositionReporting {
             if (Rlat0 >= 270.0 && Rlat0 <= 360.0) Rlat0 -= 360.0;
             if (Rlat1 >= 270.0 && Rlat1 <= 360.0) Rlat1 -= 360.0;
         } else {
-            if (Rlat0 - reference.getLatitude() > 45.0) Rlat0 -= 90.0;
-            if (Rlat1 - reference.getLatitude() > 45.0) Rlat1 -= 90.0;
+            if (Rlat0 == 0 && reference.getLatitude() > 45) Rlat0 = 90.0;
+            else if (Rlat0 - reference.getLatitude() > 45.0) Rlat0 -= 90.0;
+            if (Rlat1 == 0 && reference.getLatitude() > 45) Rlat1 = 90.0;
+            else if (Rlat1 - reference.getLatitude() > 45.0) Rlat1 -= 90.0;
         }
 
         // ensure that the number of even longitude zones are equal

--- a/src/test/java/de/serosystems/lib1090/GlobalPositionDecodingTest.java
+++ b/src/test/java/de/serosystems/lib1090/GlobalPositionDecodingTest.java
@@ -103,6 +103,12 @@ public class GlobalPositionDecodingTest {
             Position ref = new Position(-110., -10., 0.);
             test(true, 0x179ED, 0x1595F, 0x037E4, 0x0EC11, ref, expected);
         }
+        {
+            // Special cases: Equator vs Poles
+            test(true, 0x00000, 0x00000, 0x00000, 0x00000, new Position(0.,10.,0.), new Position(0.,0.,0.));
+            test(true, 0x00000, 0x00000, 0x00000, 0x00000, new Position(0.,60.,0.), new Position(0.,90.,0.));
+            test(true, 0x00000, 0x00000, 0x00000, 0x00000, new Position(0.,-60.,0.), new Position(0.,-90.,0.));
+        }
     }
 
     @Test


### PR DESCRIPTION
# Description

Global CPR fails for surface positions on Southern Hemisphere.

When decoding surface positions with global CPR, the reconstructed latitude in always restricted to `[0,90)`. It is considered a candidate and its Southern Hemisphere counterpart is shifted by `-90°`. Which one to chose must be decided by the reference position.

Lib1090 misses this distinction and always uses the reconstructed latitude which is always in the Northern Hemisphere.
This in turn also decodes a wrong longitude, since longitude decoding depends on the correct latitude.

## Fix

The candidate latitude which is closer to the reference latitude is chosen.

## Additional Information

Also added unit tests to global position decoding.
