### PR TITLE
Fix file names of TargetStateAndStatusMsg V1/V2 according to convention

### DIFF
--- a/src/main/java/de/serosystems/example/ExampleDecoder.java
+++ b/src/main/java/de/serosystems/example/ExampleDecoder.java
@@ -300,8 +300,8 @@ public class ExampleDecoder {
 				break;
 			case ADSB_TARGET_STATE_AND_STATUS:
 				System.out.println("["+icao24+"]: Target State and Status reported");
-				if (msg instanceof TargetStateAndStatusMsgV1) {
-					TargetStateAndStatusMsgV1 tStatus = (TargetStateAndStatusMsgV1) msg;
+				if (msg instanceof TargetStateAndStatusV1Msg) {
+					TargetStateAndStatusV1Msg tStatus = (TargetStateAndStatusV1Msg) msg;
 					System.out.println("          Navigation Accuracy Category for position (NACp): " + tStatus.getNACp());
 					System.out.println("          Has operational TCAS: " + tStatus.hasOperationalTCAS());
 					System.out.println("          Surveillance/Source Integrity Level (SIL): " + tStatus.getSIL());
@@ -318,7 +318,7 @@ public class ExampleDecoder {
 					}
 				} else {
 
-					TargetStateAndStatusMsgV2 tStatus = (TargetStateAndStatusMsgV2) msg;
+					TargetStateAndStatusV2Msg tStatus = (TargetStateAndStatusV2Msg) msg;
 					System.out.println("          Navigation Accuracy Category for position (NACp): " + tStatus.getNACp());
 					System.out.println("          Has operational TCAS: " + tStatus.hasOperationalTCAS());
 					System.out.println("          Surveillance/Source Integrity Level (SIL): " + tStatus.getSIL());

--- a/src/main/java/de/serosystems/lib1090/StatefulModeSDecoder.java
+++ b/src/main/java/de/serosystems/lib1090/StatefulModeSDecoder.java
@@ -405,9 +405,9 @@ public class StatefulModeSDecoder {
 		if (ftc == 29) {
 			int subtype = (es1090.getMessage()[0] >>> 1) & 0x3;
 			if (subtype == 0 && dd.adsbVersion == 1) {
-				return new TargetStateAndStatusMsgV1(es1090);
+				return new TargetStateAndStatusV1Msg(es1090);
 			} else if (subtype == 1 && dd.adsbVersion == 2) {
-				return new TargetStateAndStatusMsgV2(es1090);
+				return new TargetStateAndStatusV2Msg(es1090);
 			}
 		}
 

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/AirborneVelocityMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/AirborneVelocityMsg.java
@@ -23,7 +23,7 @@ import de.serosystems.lib1090.decoding.AirborneVelocity;
 /**
  * Common API for ADS-B airborne velocity messages across message subtypes.
  */
-public interface AirborneVelocityMessage {
+public interface AirborneVelocityMsg {
 
 	/**
 	 * @return true if the aircraft indicates an intent to change altitude or a similar flight status change

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/AirspeedHeadingMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/AirspeedHeadingMsg.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * Decoder for ADS-B airspeed and heading messages
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
-public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMessage {
+public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMsg {
 
 	private static final long serialVersionUID = 6901092011249128775L;
 

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusV1Msg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusV1Msg.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
 /**
  * Decoder for ADS-B target state and status message as specified in DO-260A (ADS-B version 1).
  */
-public class TargetStateAndStatusMsgV1 extends ExtendedSquitter implements Serializable, TargetStateAndStatusMsg {
+public class TargetStateAndStatusV1Msg extends ExtendedSquitter implements Serializable, TargetStateAndStatusMsg {
 
 	private static final long serialVersionUID = -3226687215928593692L;
 
@@ -49,14 +49,14 @@ public class TargetStateAndStatusMsgV1 extends ExtendedSquitter implements Seria
 	private byte emergency_priority_status;
 
 	/** protected no-arg constructor e.g. for serialization with Kryo **/
-	protected TargetStateAndStatusMsgV1() { }
+	protected TargetStateAndStatusV1Msg() { }
 
 	/**
 	 * @param raw_message The full Mode S message in hex representation
 	 * @throws BadFormatException if message has the wrong typecode or ADS-B version
 	 * @throws UnspecifiedFormatError if message has the wrong subtype
 	 */
-	public TargetStateAndStatusMsgV1(String raw_message) throws BadFormatException, UnspecifiedFormatError {
+	public TargetStateAndStatusV1Msg(String raw_message) throws BadFormatException, UnspecifiedFormatError {
 		this(new ExtendedSquitter(raw_message));
 	}
 
@@ -65,7 +65,7 @@ public class TargetStateAndStatusMsgV1 extends ExtendedSquitter implements Seria
 	 * @throws BadFormatException if message has the wrong typecode or ADS-B version
 	 * @throws UnspecifiedFormatError if message has the wrong subtype
 	 */
-	public TargetStateAndStatusMsgV1(byte[] raw_message) throws BadFormatException, UnspecifiedFormatError {
+	public TargetStateAndStatusV1Msg(byte[] raw_message) throws BadFormatException, UnspecifiedFormatError {
 		this(new ExtendedSquitter(raw_message));
 	}
 
@@ -74,7 +74,7 @@ public class TargetStateAndStatusMsgV1 extends ExtendedSquitter implements Seria
 	 * @throws BadFormatException if message has the wrong typecode
 	 * @throws UnspecifiedFormatError if message has the wrong subtype
 	 */
-	public TargetStateAndStatusMsgV1(ExtendedSquitter squitter) throws BadFormatException, UnspecifiedFormatError {
+	public TargetStateAndStatusV1Msg(ExtendedSquitter squitter) throws BadFormatException, UnspecifiedFormatError {
 		super(squitter);
 		setType(subtype.ADSB_TARGET_STATE_AND_STATUS);
 

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusV2Msg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusV2Msg.java
@@ -29,7 +29,7 @@ import java.io.Serializable;
  *
  * @author Markus Fuchs (fuchs@opensky-network.org)
  */
-public class TargetStateAndStatusMsgV2 extends ExtendedSquitter implements Serializable, TargetStateAndStatusMsg {
+public class TargetStateAndStatusV2Msg extends ExtendedSquitter implements Serializable, TargetStateAndStatusMsg {
 
 	private static final long serialVersionUID = 7485953168219273935L;
 
@@ -52,14 +52,14 @@ public class TargetStateAndStatusMsgV2 extends ExtendedSquitter implements Seria
 	private boolean lnav_mode_engaged;
 
 	/** protected no-arg constructor e.g. for serialization with Kryo **/
-	protected TargetStateAndStatusMsgV2() { }
+	protected TargetStateAndStatusV2Msg() { }
 
 	/**
 	 * @param raw_message The full Mode S message in hex representation
 	 * @throws BadFormatException if message has the wrong typecode or ADS-B version
 	 * @throws UnspecifiedFormatError if message has the wrong subtype
 	 */
-	public TargetStateAndStatusMsgV2(String raw_message) throws BadFormatException, UnspecifiedFormatError {
+	public TargetStateAndStatusV2Msg(String raw_message) throws BadFormatException, UnspecifiedFormatError {
 		this(new ExtendedSquitter(raw_message));
 	}
 
@@ -68,7 +68,7 @@ public class TargetStateAndStatusMsgV2 extends ExtendedSquitter implements Seria
 	 * @throws BadFormatException if message has the wrong typecode or ADS-B version
 	 * @throws UnspecifiedFormatError if message has the wrong subtype
 	 */
-	public TargetStateAndStatusMsgV2(byte[] raw_message) throws BadFormatException, UnspecifiedFormatError {
+	public TargetStateAndStatusV2Msg(byte[] raw_message) throws BadFormatException, UnspecifiedFormatError {
 		this(new ExtendedSquitter(raw_message));
 	}
 
@@ -77,7 +77,7 @@ public class TargetStateAndStatusMsgV2 extends ExtendedSquitter implements Seria
 	 * @throws BadFormatException  if message has the wrong typecode or if reserved bits are set
 	 * @throws UnspecifiedFormatError if message has the wrong subtype
 	 */
-	public TargetStateAndStatusMsgV2(ExtendedSquitter squitter) throws BadFormatException, UnspecifiedFormatError {
+	public TargetStateAndStatusV2Msg(ExtendedSquitter squitter) throws BadFormatException, UnspecifiedFormatError {
 		super(squitter);
 		setType(subtype.ADSB_TARGET_STATE_AND_STATUS);
 

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/VelocityOverGroundMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/VelocityOverGroundMsg.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * Decoder for ADS-B velocity messages
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
-public class VelocityOverGroundMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMessage {
+public class VelocityOverGroundMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMsg {
 
 	private static final long serialVersionUID = 1774082354457574555L;
 

--- a/src/main/java/de/serosystems/lib1090/msgs/adsr/AirborneVelocityMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsr/AirborneVelocityMsg.java
@@ -16,14 +16,14 @@
  *  along with de.serosystems.lib1090.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package de.serosystems.lib1090.msgs.tisb;
+package de.serosystems.lib1090.msgs.adsr;
 
 import de.serosystems.lib1090.decoding.AirborneVelocity;
 
 /**
- * Common API for TIS-B airborne velocity messages across message subtypes.
+ * Common API for ADS-R airborne velocity messages across message subtypes.
  */
-public interface AirborneVelocityMessage {
+public interface AirborneVelocityMsg {
 
 	/**
 	 * @return the ICAO Mode A Flag used for address type determination
@@ -31,25 +31,32 @@ public interface AirborneVelocityMessage {
 	boolean getIMF();
 
 	/**
+	 * Note: only defined for ADS-R version 0 and 1.
+	 * @return true if the aircraft reports IFR capability
+	 */
+	boolean hasIFRCapability();
+
+	/**
+	 * @return the raw encoded Navigation Accuracy Category for velocity
+	 */
+	byte getNACv();
+
+	/**
+	 * @return the interpreted 95% horizontal velocity accuracy in m/s, or -1 if unknown or greater than 10m/s
+	 */
+	default float getAccuracyBound() {
+		return AirborneVelocity.decodeAccuracyBound(getNACv());
+	}
+
+	/**
 	 * @return whether the vertical rate field is available
 	 */
 	boolean hasVerticalRateInfo();
 
 	/**
-	 * @return the raw encoded Navigation Accuracy Category for velocity, or {@code null} if unavailable
+	 * @return whether the reported vertical speed is barometric
 	 */
-	Byte getNACv();
-
-	/**
-	 * @return the interpreted 95% horizontal velocity accuracy in m/s, or {@code null} if unavailable
-	 */
-	default Float getAccuracyBound() {
-		Byte nacv = getNACv();
-		if (nacv == null) {
-			return null;
-		}
-		return AirborneVelocity.decodeAccuracyBound(nacv);
-	}
+	boolean isBarometricVerticalSpeed();
 
 	/**
 	 * @return the vertical rate in feet/min, or {@code null} if unavailable

--- a/src/main/java/de/serosystems/lib1090/msgs/adsr/AirspeedHeadingMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsr/AirspeedHeadingMsg.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * Decoder for ADS-R airspeed and heading messages
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
-public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMessage {
+public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMsg {
 
 	private static final long serialVersionUID = -5847938116356997891L;
 

--- a/src/main/java/de/serosystems/lib1090/msgs/adsr/VelocityOverGroundMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsr/VelocityOverGroundMsg.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * Decoder for ADS-R velocity messages
  * @author Matthias Schäfer (schaefer@sero-systems.de)
  */
-public class VelocityOverGroundMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMessage {
+public class VelocityOverGroundMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMsg {
 
 	private static final long serialVersionUID = -4871907161197614315L;
 

--- a/src/main/java/de/serosystems/lib1090/msgs/tisb/AirborneVelocityMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/tisb/AirborneVelocityMsg.java
@@ -16,14 +16,14 @@
  *  along with de.serosystems.lib1090.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package de.serosystems.lib1090.msgs.adsr;
+package de.serosystems.lib1090.msgs.tisb;
 
 import de.serosystems.lib1090.decoding.AirborneVelocity;
 
 /**
- * Common API for ADS-R airborne velocity messages across message subtypes.
+ * Common API for TIS-B airborne velocity messages across message subtypes.
  */
-public interface AirborneVelocityMessage {
+public interface AirborneVelocityMsg {
 
 	/**
 	 * @return the ICAO Mode A Flag used for address type determination
@@ -31,32 +31,25 @@ public interface AirborneVelocityMessage {
 	boolean getIMF();
 
 	/**
-	 * Note: only defined for ADS-R version 0 and 1.
-	 * @return true if the aircraft reports IFR capability
-	 */
-	boolean hasIFRCapability();
-
-	/**
-	 * @return the raw encoded Navigation Accuracy Category for velocity
-	 */
-	byte getNACv();
-
-	/**
-	 * @return the interpreted 95% horizontal velocity accuracy in m/s, or -1 if unknown or greater than 10m/s
-	 */
-	default float getAccuracyBound() {
-		return AirborneVelocity.decodeAccuracyBound(getNACv());
-	}
-
-	/**
 	 * @return whether the vertical rate field is available
 	 */
 	boolean hasVerticalRateInfo();
 
 	/**
-	 * @return whether the reported vertical speed is barometric
+	 * @return the raw encoded Navigation Accuracy Category for velocity, or {@code null} if unavailable
 	 */
-	boolean isBarometricVerticalSpeed();
+	Byte getNACv();
+
+	/**
+	 * @return the interpreted 95% horizontal velocity accuracy in m/s, or {@code null} if unavailable
+	 */
+	default Float getAccuracyBound() {
+		Byte nacv = getNACv();
+		if (nacv == null) {
+			return null;
+		}
+		return AirborneVelocity.decodeAccuracyBound(nacv);
+	}
 
 	/**
 	 * @return the vertical rate in feet/min, or {@code null} if unavailable

--- a/src/main/java/de/serosystems/lib1090/msgs/tisb/AirspeedHeadingMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/tisb/AirspeedHeadingMsg.java
@@ -30,7 +30,7 @@ import java.io.Serializable;
  * Decoder for TIS-B airspeed+heading message (DO-260B, 2.2.17.3.4).
  * @author Matthias Schaefer (schaefer@sero-systems.de)
  */
-public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMessage {
+public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMsg {
 
 	private static final long serialVersionUID = 944130622021621845L;
 

--- a/src/main/java/de/serosystems/lib1090/msgs/tisb/VelocityOverGroundMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/tisb/VelocityOverGroundMsg.java
@@ -30,7 +30,7 @@ import java.io.Serializable;
  * Decoder for TIS-B velocity message (DO-260B, 2.2.17.3.4).
  * @author Matthias Schaefer (schaefer@sero-systems.de)
  */
-public class VelocityOverGroundMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMessage {
+public class VelocityOverGroundMsg extends ExtendedSquitter implements Serializable, AirborneVelocityMsg {
 
 	private static final long serialVersionUID = 4633940058263818959L;
 

--- a/src/test/java/de/serosystems/lib1090/StatefulModeSDecoderTest.java
+++ b/src/test/java/de/serosystems/lib1090/StatefulModeSDecoderTest.java
@@ -24,10 +24,10 @@ import de.serosystems.lib1090.msgs.ModeSDownlinkMsg;
 import de.serosystems.lib1090.msgs.adsb.ModeACodeV1Msg;
 import de.serosystems.lib1090.msgs.adsb.ModeACodeV1MsgTest;
 import de.serosystems.lib1090.msgs.adsb.OperationalStatusMsgTest;
-import de.serosystems.lib1090.msgs.adsb.TargetStateAndStatusMsgV1;
-import de.serosystems.lib1090.msgs.adsb.TargetStateAndStatusMsgV1Test;
-import de.serosystems.lib1090.msgs.adsb.TargetStateAndStatusMsgV2;
-import de.serosystems.lib1090.msgs.adsb.TargetStateAndStatusMsgV2Test;
+import de.serosystems.lib1090.msgs.adsb.TargetStateAndStatusV1Msg;
+import de.serosystems.lib1090.msgs.adsb.TargetStateAndStatusV1MsgTest;
+import de.serosystems.lib1090.msgs.adsb.TargetStateAndStatusV2Msg;
+import de.serosystems.lib1090.msgs.adsb.TargetStateAndStatusV2MsgTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +49,7 @@ public class StatefulModeSDecoderTest {
 	@Test
 	public void tssV0Me11Set_shouldNotDecode() throws UnspecifiedFormatError, BadFormatException {
 		// decoder assumes ADS-B v0 and should not decode TSS
-		final ModeSDownlinkMsg reply = decoder.decode(TargetStateAndStatusMsgV2Test.TSS_WITH_ME11_BIT_SET, 0L);
+		final ModeSDownlinkMsg reply = decoder.decode(TargetStateAndStatusV2MsgTest.TSS_WITH_ME11_BIT_SET, 0L);
 
 		assertEquals(ModeSDownlinkMsg.subtype.EXTENDED_SQUITTER, reply.getType());
 		assertNotEquals(ModeSDownlinkMsg.subtype.ADSB_TARGET_STATE_AND_STATUS, reply.getType());
@@ -61,11 +61,11 @@ public class StatefulModeSDecoderTest {
 		decoder.decode(OperationalStatusMsgTest.A_OPSTAT_V2, 0L);
 
 		// decode message with ME bit 11 set
-		final ModeSDownlinkMsg reply = decoder.decode(TargetStateAndStatusMsgV2Test.TSS_WITH_ME11_BIT_SET, 0L);
+		final ModeSDownlinkMsg reply = decoder.decode(TargetStateAndStatusV2MsgTest.TSS_WITH_ME11_BIT_SET, 0L);
 
 		assertEquals(ModeSDownlinkMsg.subtype.ADSB_TARGET_STATE_AND_STATUS, reply.getType());
 
-		TargetStateAndStatusMsgV2 tss = (TargetStateAndStatusMsgV2) reply;
+		TargetStateAndStatusV2Msg tss = (TargetStateAndStatusV2Msg) reply;
 
 		assertFalse(tss.hasSILSupplement());
 		assertFalse(tss.isFMSSelectedAltitude());
@@ -74,22 +74,22 @@ public class StatefulModeSDecoderTest {
 
 	@Test
 	public void tssV1_shouldDecode() throws UnspecifiedFormatError, BadFormatException {
-		decoder.decode(TargetStateAndStatusMsgV1Test.A_OPSTAT_V1, 0L);
+		decoder.decode(TargetStateAndStatusV1MsgTest.A_OPSTAT_V1, 0L);
 
-		final ModeSDownlinkMsg reply = decoder.decode(TargetStateAndStatusMsgV1Test.TSS_V1, 0L);
+		final ModeSDownlinkMsg reply = decoder.decode(TargetStateAndStatusV1MsgTest.TSS_V1, 0L);
 
 		assertEquals(ModeSDownlinkMsg.subtype.ADSB_TARGET_STATE_AND_STATUS, reply.getType());
 
-		assertTrue(reply instanceof TargetStateAndStatusMsgV1);
+		assertTrue(reply instanceof TargetStateAndStatusV1Msg);
 
-		TargetStateAndStatusMsgV1 tss = (TargetStateAndStatusMsgV1) reply;
+		TargetStateAndStatusV1Msg tss = (TargetStateAndStatusV1Msg) reply;
 
 		assertEquals(9, tss.getNACp());
 	}
 
 	@Test
 	public void modeACodeV1_shouldDecode() throws UnspecifiedFormatError, BadFormatException {
-		decoder.decode(TargetStateAndStatusMsgV1Test.A_OPSTAT_V1, 0L);
+		decoder.decode(TargetStateAndStatusV1MsgTest.A_OPSTAT_V1, 0L);
 
 		final ModeSDownlinkMsg reply = decoder.decode(ModeACodeV1MsgTest.MODE_A_CODE_V1, 0L);
 

--- a/src/test/java/de/serosystems/lib1090/msgs/adsb/AirspeedHeadingMsgTest.java
+++ b/src/test/java/de/serosystems/lib1090/msgs/adsb/AirspeedHeadingMsgTest.java
@@ -55,7 +55,7 @@ class AirspeedHeadingMsgTest {
 	@Test
 	public void testImplementsAirborneVelocityMessage() throws Exception {
 		AirspeedHeadingMsg msg = new AirspeedHeadingMsg("8DA05F219B06B6AF189400CBC33F");
-		assertInstanceOf(AirborneVelocityMessage.class, msg);
+		assertInstanceOf(AirborneVelocityMsg.class, msg);
 	}
 
 	@Test

--- a/src/test/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusV1MsgTest.java
+++ b/src/test/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusV1MsgTest.java
@@ -31,14 +31,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TargetStateAndStatusMsgV1Test {
+public class TargetStateAndStatusV1MsgTest {
 
-	public static final String TSS_V1 = withSubtype(TargetStateAndStatusMsgV2Test.TSS_WITHOUT_HEADING, 0);
+	public static final String TSS_V1 = withSubtype(TargetStateAndStatusV2MsgTest.TSS_WITHOUT_HEADING, 0);
 	public static final String A_OPSTAT_V1 = withAddress("8D000000F8000200492900000000", "89653e");
 
 	@Test
 	public void testDecodeTssV1() throws UnspecifiedFormatError, BadFormatException {
-		final TargetStateAndStatusMsgV1 tss = new TargetStateAndStatusMsgV1(Tools.hexStringToByteArray(TSS_V1));
+		final TargetStateAndStatusV1Msg tss = new TargetStateAndStatusV1Msg(Tools.hexStringToByteArray(TSS_V1));
 
 		assertEquals("89653e", tss.getAddress().getHexAddress());
 		assertEquals(17, tss.getDownlinkFormat());

--- a/src/test/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusV2MsgTest.java
+++ b/src/test/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusV2MsgTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Markus Fuchs (fuchs@opensky-network.org)
  */
-public class TargetStateAndStatusMsgV2Test {
+public class TargetStateAndStatusV2MsgTest {
 
 	// A TSS report observed in reality, decomposed by single bits
 	public static final String TSS_WITHOUT_HEADING =
@@ -138,7 +138,7 @@ public class TargetStateAndStatusMsgV2Test {
 
 	@Test
 	public void testTssWithoutHeading() throws UnspecifiedFormatError, BadFormatException {
-		final TargetStateAndStatusMsgV2 tss = new TargetStateAndStatusMsgV2(Tools.hexStringToByteArray(TSS_WITHOUT_HEADING));
+		final TargetStateAndStatusV2Msg tss = new TargetStateAndStatusV2Msg(Tools.hexStringToByteArray(TSS_WITHOUT_HEADING));
 
 		assertEquals("89653e", tss.getAddress().getHexAddress());
 		assertEquals(17, tss.getDownlinkFormat());
@@ -167,7 +167,7 @@ public class TargetStateAndStatusMsgV2Test {
 
 	@Test
 	public void testTssWithHeadingLt180Degrees() throws UnspecifiedFormatError, BadFormatException {
-		final TargetStateAndStatusMsgV2 tss = new TargetStateAndStatusMsgV2(Tools.hexStringToByteArray(TSS_HEADING_LT_180_DEG));
+		final TargetStateAndStatusV2Msg tss = new TargetStateAndStatusV2Msg(Tools.hexStringToByteArray(TSS_HEADING_LT_180_DEG));
 
 		assertEquals("89653e", tss.getAddress().getHexAddress());
 		assertEquals(17, tss.getDownlinkFormat());
@@ -196,7 +196,7 @@ public class TargetStateAndStatusMsgV2Test {
 
 	@Test
 	public void testTssWithHeadingGt180Degrees() throws UnspecifiedFormatError, BadFormatException {
-		final TargetStateAndStatusMsgV2 tss = new TargetStateAndStatusMsgV2(Tools.hexStringToByteArray(TSS_HEADING_GT_180_DEG));
+		final TargetStateAndStatusV2Msg tss = new TargetStateAndStatusV2Msg(Tools.hexStringToByteArray(TSS_HEADING_GT_180_DEG));
 
 		assertEquals("89653e", tss.getAddress().getHexAddress());
 		assertEquals(17, tss.getDownlinkFormat());
@@ -226,7 +226,7 @@ public class TargetStateAndStatusMsgV2Test {
 	@Test
 	public void testInvalidReservedBits_shouldThrowBadFormatException() {
 		try {
-			final TargetStateAndStatusMsgV2 tss = new TargetStateAndStatusMsgV2(Tools.hexStringToByteArray(INVALID_TSS));
+			final TargetStateAndStatusV2Msg tss = new TargetStateAndStatusV2Msg(Tools.hexStringToByteArray(INVALID_TSS));
 			fail();
 		} catch (BadFormatException e) {
 			// NOP

--- a/src/test/java/de/serosystems/lib1090/msgs/adsb/VelocityOverGroundMsgTest.java
+++ b/src/test/java/de/serosystems/lib1090/msgs/adsb/VelocityOverGroundMsgTest.java
@@ -54,7 +54,7 @@ class VelocityOverGroundMsgTest {
 	@Test
 	public void testImplementsAirborneVelocityMessage() throws Exception {
 		VelocityOverGroundMsg msg = new VelocityOverGroundMsg("8D485020994409940838175B284F");
-		assertInstanceOf(AirborneVelocityMessage.class, msg);
+		assertInstanceOf(AirborneVelocityMsg.class, msg);
 	}
 
 	@Test


### PR DESCRIPTION
In commit ca3b15771529ee3a83480229b9ba9ff6558e995c class `TargetStateAndStatusMsg` was split into V1/V2. However, the postfix `V1` resp. `V2` was appended _after_ `Msg`.
This is against the convention (see other class names for reference).
Also renamed test files and adapted the `ExampleDecoder`.

Additionally, in commit 49aa528792a2411992033c614e23fa9926208934 class `AirborneVelocityMessage` was added (for ads-b, ads-r and tis-b) which should have been named `AirborneVelocityMsg`.
