### PR TITLE
Fix CPR NL() off-by-one at the 87 deg polar boundary

### DIFF
--- a/src/main/java/de/serosystems/lib1090/cpr/L0Latitude.java
+++ b/src/main/java/de/serosystems/lib1090/cpr/L0Latitude.java
@@ -145,7 +145,14 @@ class L0Latitude {
      * @return number of longitude zones for this latitude.
      */
     public int NL() {
-        int idx = Arrays.binarySearch(T_LAT, Math.abs(lat));
+        int abslat = Math.abs(lat);
+        // The topmost transition latitude (87°, = T_LAT[last]) lands exactly on a
+        // lattice point. Per DO-260B (and NASA's reference nl_double), NL == 1 for
+        // |lat| >= 87°, so the top boundary is *exclusive* for the NL=2 zone: a
+        // position sitting exactly on it belongs to the polar cap (NL=1). Without
+        // this, an exact binarySearch hit on T_LAT[last] would yield NL=2.
+        if (abslat >= T_LAT[T_LAT.length - 1]) return 1;
+        int idx = Arrays.binarySearch(T_LAT, abslat);
         if (idx < 0) idx = -idx - 1;
         return T_LAT.length - idx + 1;
     }

--- a/src/test/java/de/serosystems/lib1090/cpr/L0LatitudeTest.java
+++ b/src/test/java/de/serosystems/lib1090/cpr/L0LatitudeTest.java
@@ -1,0 +1,63 @@
+/*
+ *  This file is part of lib1090.
+ *  Copyright (C) 2026 SeRo Systems GmbH
+ *
+ *  lib1090 is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  lib1090 is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with de.serosystems.lib1090.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.serosystems.lib1090.cpr;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for {@link L0Latitude#NL()}, in particular the polar
+ * transition latitude (87°) which lands exactly on a lattice point.
+ */
+public class L0LatitudeTest {
+
+    /**
+     * Per DO-260B / NASA reference: NL == 1 for |lat| >= 87°. Because 87.0°
+     * is an exact lattice point and the topmost transition latitude, the top
+     * boundary must be exclusive for the NL=2 zone. This is the regression
+     * for the off-by-one that returned NL=2 exactly at 87°.
+     */
+    @Test
+    public void nlAtPolarBoundaryIsOne() {
+        assertEquals(1, L0Latitude.ofDegrees(87.0).NL(), "NL at exactly 87.0° must be 1");
+        assertEquals(1, L0Latitude.ofDegrees(-87.0).NL(), "NL at exactly -87.0° must be 1");
+        assertEquals(1, L0Latitude.ofDegrees(88.5).NL(), "NL above 87° must be 1");
+        assertEquals(1, L0Latitude.ofDegrees(90.0).NL(), "NL at the pole must be 1");
+    }
+
+    /**
+     * Just below the polar boundary NL must still be 2 (the boundary is
+     * exclusive only at the top edge, the zone below is unaffected).
+     */
+    @Test
+    public void nlJustBelowPolarBoundaryIsTwo() {
+        assertEquals(2, L0Latitude.ofDegrees(86.999).NL(), "NL just below 87° must be 2");
+        assertEquals(2, L0Latitude.ofDegrees(86.6).NL(), "NL inside the NL=2 zone must be 2");
+    }
+
+    /**
+     * Anchor points of the NL step function at and near the equator.
+     */
+    @Test
+    public void nlAtEquatorIs59() {
+        assertEquals(59, L0Latitude.ofDegrees(0.0).NL(), "NL at the equator must be 59");
+        assertEquals(59, L0Latitude.ofDegrees(10.0).NL(), "NL at 10° must be 59");
+    }
+}


### PR DESCRIPTION
Fixes an off-by-one in `L0Latitude.NL()` at exactly |lat| = 87.0 deg.

## Problem
The topmost transition latitude `T_LAT[57]` rounds to exactly 87.0 deg and `binarySearch` matched it inclusively, so `NL()` returned 2 at |lat| = 87.0 deg, where the DO-260B standard (and the NASA/cpr formally-verified reference) require NL = 1 (polar cap). This changes longitude decoding for positions landing exactly on the 87 deg lattice point.

## Fix
Treat the top transition latitude as exclusive for the NL=2 zone:
```java
if (abslat >= T_LAT[T_LAT.length - 1]) return 1;   // |lat| >= 87 deg -> polar cap
```
Only the topmost boundary changes (it is the only NL transition latitude landing exactly on an exact integer-lattice point); the other 57 already matched NASA at every lattice point.

## Validation
- New regression test `cpr/L0LatitudeTest.java`: NL==1 at +/-87/88.5/90 deg, NL==2 just below 87 deg, NL==59 at the equator.
- Full suite: 164 tests pass, 0 failures.
- Cross-checked against the NASA/cpr DO-260B reference: NL boundaries agree to ~2 cm; an exhaustive lattice check around all 58 NL boundaries now matches; a 1,000,000-position airborne+surface decode cross-check against NASA agrees to ~5 mm.
- Independently validated with GPT-5.5 (Codex).

Commit: 08b5ec6