### PR TITLE
docs: fix standards-compliance issues in ADS-B/Mode S decoding

### DIFF
--- a/src/main/java/de/serosystems/lib1090/decoding/Identification.java
+++ b/src/main/java/de/serosystems/lib1090/decoding/Identification.java
@@ -107,7 +107,7 @@ public final class Identification {
 				"Reserved",
 				"Reserved"
 		},{
-				"Reserved",
+				"No ADS-B Emitter Category Information",
 				"Reserved",
 				"Reserved",
 				"Reserved",

--- a/src/main/java/de/serosystems/lib1090/msgs/ModeSDownlinkMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/ModeSDownlinkMsg.java
@@ -290,9 +290,9 @@ public class ModeSDownlinkMsg implements Serializable {
 
 		// DF 24 is a special case
 		if (downlink_format > 23) {
-			// verify that the third most significant bit is 1
+			// verify that the third most significant bit is 0 (DF=24 is 11000)
 			if ((downlink_format & 0b00000100) != 0) {
-				throw new BadFormatException("Third MSB of Comm-D Extended Length Message must be 1");
+				throw new BadFormatException("Third MSB of Comm-D Extended Length Message must be 0");
 			}
 
 			downlink_format = 24;

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/AirborneOperationalStatusV2Msg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/AirborneOperationalStatusV2Msg.java
@@ -108,12 +108,21 @@ public class AirborneOperationalStatusV2Msg extends AirborneOperationalStatusV1M
 	}
 
 	/**
-	 * @return the geometric vertical accuracy in meters or -1 for "unknown or above 150m"
+	 * Geometric Vertical Accuracy (GVA), DO-260B Table 2-71 (§2.2.3.2.7.2.8):
+	 * encoding 0 = "Unknown or &gt; 150 m", 1 = "&le; 150 m", 2 = "&lt; 45 m", 3 = "Reserved".
+	 * Per the Table 2-71 Note, ADS-B Version 2 receivers treat encoding 3 (which future
+	 * versions &gt; 2 define as &lt; 45 m) as &lt; 45 m rather than as fully unknown.
+	 * The raw encoding is available via {@link #getGVA()}.
+	 *
+	 * @return the geometric vertical accuracy in meters, or -1 for "unknown or above 150m" (encoding 0)
 	 */
 	public int getGeometricVerticalAccuracy() {
 		if (geometric_vertical_accuracy == 1)
 			return 150;
 		else if (geometric_vertical_accuracy == 2)
+			return 45;
+		else if (geometric_vertical_accuracy == 3)
+			// Reserved in DO-260B; per Table 2-71 Note, V2 receivers treat it as < 45 m.
 			return 45;
 		else return -1;
 	}

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/AirspeedHeadingMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/AirspeedHeadingMsg.java
@@ -43,7 +43,7 @@ public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable
 	private boolean airspeed_available;
 	private boolean vertical_source; // 0 = geometric, 1 = barometric
 	private boolean vertical_rate_down; // 0 = up, 1 = down
-	private short vertical_rate; // in ft/s
+	private short vertical_rate; // in ft/min
 	private boolean vertical_rate_info_available;
 	private int geo_minus_baro; // in ft
 	private boolean geo_minus_baro_available;
@@ -214,7 +214,9 @@ public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable
 	}
 
 	/**
-	 * @return heading in decimal degrees ([0, 360]). 0° = geographic north or null if no information is available.
+	 * @return heading in decimal degrees ([0, 360)). 0° = magnetic north for ADS-B version 0/1; for version 2 the
+	 *         reference direction (true or magnetic) is signalled externally by the Horizontal Reference Direction
+	 *         (HRD) bit in the Operational Status message. Returns null if no information is available.
 	 * The latter can also be checked using {@link #hasHeadingStatusFlag()}.
 	 */
 	public Double getHeading() {

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/EmergencyOrPriorityStatusMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/EmergencyOrPriorityStatusMsg.java
@@ -105,6 +105,7 @@ public class EmergencyOrPriorityStatusMsg extends ExtendedSquitter implements Se
 		case 4: return "no communications";
 		case 5: return "unlawful interference";
 		case 6: return "downed aircraft";
+		case 7: return "reserved";
 		default: return "unknown";
 		}
 	}

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/MLATSystemStatusMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/MLATSystemStatusMsg.java
@@ -58,7 +58,7 @@ public class MLATSystemStatusMsg extends ExtendedSquitter implements Serializabl
 	}
 
 	/**
-	 * @param squitter extended squitter which contains this identification msg
+	 * @param squitter extended squitter which contains this MLAT/Surface System Status msg
 	 * @throws BadFormatException if message has the wrong typecode
 	 */
 	public MLATSystemStatusMsg(ExtendedSquitter squitter) throws BadFormatException {

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/TargetStateAndStatusMsg.java
@@ -55,7 +55,7 @@ public interface TargetStateAndStatusMsg {
 	  * is referring to true north or magnetic north.
 	  * If information is not available, assume magnetic north as the de-facto standard.
 	  *
-	  * @return the selected heading in decimal degrees ([0, 360]) clockwise, or {@code null} if unavailable
+	  * @return the selected heading in decimal degrees ([0, 360)) clockwise, or {@code null} if unavailable
 	 */
 	Float getSelectedHeading();
 

--- a/src/main/java/de/serosystems/lib1090/msgs/adsb/VelocityOverGroundMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsb/VelocityOverGroundMsg.java
@@ -162,7 +162,7 @@ public class VelocityOverGroundMsg extends ExtendedSquitter implements Serializa
 	}
 
 	/**
-	 * @return velocity from east to south in knots or null if information is not available
+	 * @return velocity from east to west in knots or null if information is not available
 	 */
 	public Integer getEastToWestVelocity() {
 		if (!velocity_info_available) return null;

--- a/src/main/java/de/serosystems/lib1090/msgs/adsr/AirspeedHeadingMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/adsr/AirspeedHeadingMsg.java
@@ -43,7 +43,7 @@ public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable
 	private boolean airspeed_available;
 	private boolean vertical_source; // 0 = geometric, 1 = barometric
 	private boolean vertical_rate_down; // 0 = up, 1 = down
-	private short vertical_rate; // in ft/s
+	private short vertical_rate; // in ft/min
 	private boolean vertical_rate_info_available;
 	private int geo_minus_baro; // in ft
 	private boolean geo_minus_baro_available;

--- a/src/main/java/de/serosystems/lib1090/msgs/tisb/AirspeedHeadingMsg.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/tisb/AirspeedHeadingMsg.java
@@ -97,7 +97,7 @@ public class AirspeedHeadingMsg extends ExtendedSquitter implements Serializable
 
 		msg_subtype = (byte) (msg[0]&0x7);
 		if (msg_subtype != 3 && msg_subtype != 4) {
-			throw new BadFormatException("Ground speed messages have subtype 1 or 2.");
+			throw new BadFormatException("Airspeed and heading messages have subtype 3 or 4.");
 		}
 
 		imf = (msg[1]&0x80)>0;

--- a/src/main/java/de/serosystems/lib1090/msgs/tisb/ManagementMessage.java
+++ b/src/main/java/de/serosystems/lib1090/msgs/tisb/ManagementMessage.java
@@ -25,7 +25,7 @@ import de.serosystems.lib1090.msgs.modes.ExtendedSquitter;
 import java.io.Serializable;
 
 /**
- * Decoder for TIS-B Identification and Category Message (DO-260B, 2.2.17.3.3).
+ * Decoder for TIS-B/ADS-R Management Message (DO-260B, 2.2.17.3.3; CF=4).
  * @author Matthias Schaefer (schaefer@sero-systems.de)
  */
 public class ManagementMessage extends ExtendedSquitter implements Serializable {
@@ -67,7 +67,7 @@ public class ManagementMessage extends ExtendedSquitter implements Serializable 
 
 		// Table 2-13
 		if (getFirstField() != 4)
-			throw new BadFormatException("TIS-B management messages must have CF value 6.");
+			throw new BadFormatException("TIS-B management messages must have CF value 4.");
 
 		// not specified further
 	}


### PR DESCRIPTION
## Standards-compliance documentation & improvement fixes

This PR applies the **documentation-error** and **improvement** findings from a
DO-260B / DO-181E standards-compliance audit of the ADS-B / Mode S decoder
(audit run `20260715T182455Z`, subject commit `94df15f`, version
`5.0.0-SNAPSHOT`). Every change is cited to the relevant standard section/table.

Bugs and gaps from the same audit are filed as separate issues; version-specific
/ intentional observations are tracked in a single notes issue.

### Changes (11 documentation errors + 1 improvement)

- **LIB1090-022** — `decoding/Identification.java`: Category Set D code `0` is
  *"No ADS-B Emitter Category Information"*, not *"Reserved"*. Code 0 is the
  universal "no information" value across all sets. — DO-260B §2.2.3.2.5.2 &
  Table 2-19, p.86
- **LIB1090-023** — `msgs/ModeSDownlinkMsg.java`: DF=24 (Comm-D ELM) — the
  comment and exception text now correctly state the third MSB must be **0**
  (DF=24 = `11000`), matching the existing guard that throws when the bit is 1.
  — DO-181E §2.2.14.4.19/.23, p.85-86
- **LIB1090-024** — `msgs/adsb/AirspeedHeadingMsg.java`: `vertical_rate` unit
  comment corrected `ft/s` → `ft/min` (LSB = 64 ft/min). — DO-260B Table 2-29, p.94
- **LIB1090-025** — `msgs/adsb/AirspeedHeadingMsg.java`: `getHeading()` Javadoc —
  reference direction is **magnetic** north for ADS-B v0/1 and HRD-dependent
  (true/magnetic) for v2, not fixed geographic north; range `[0, 360)`. —
  DO-260B Table 2-35, p.101
- **LIB1090-026** — `msgs/adsb/EmergencyOrPriorityStatusMsg.java`: emergency
  code `7` is *"reserved"* (a defined value), not *"unknown"*. — DO-260B
  Table 2-78, p.142
- **LIB1090-027** — `msgs/adsb/MLATSystemStatusMsg.java`: fix copy-pasted
  `@param` wording (was "identification msg"). — DO-260B §2.2.3.2.7.4.3 & Table 2-77, p.141
- **LIB1090-028** — `msgs/adsb/TargetStateAndStatusMsg.java`:
  `getSelectedHeading()` documented range is `[0, 360)` (max encodable is
  359.296875°). — DO-260B Table 2-47, p.114
- **LIB1090-029** — `msgs/adsb/VelocityOverGroundMsg.java`:
  `getEastToWestVelocity()` Javadoc — "east to **west**", not "east to south". —
  DO-260B Tables 2-23/2-24, p.92
- **LIB1090-030** — `msgs/adsr/AirspeedHeadingMsg.java`: `vertical_rate` unit
  comment `ft/s` → `ft/min`. — DO-260B Table 2-29, p.94
- **LIB1090-031** — `msgs/tisb/AirspeedHeadingMsg.java`: correct exception text —
  airspeed/heading messages require subtype 3 or 4 (not "1 or 2"). — DO-260B
  §2.2.17.3.4 Figure 2-30, p.284
- **LIB1090-032** — `msgs/tisb/ManagementMessage.java`: CF value is **4**
  (TIS-B/ADS-R Management), not 6; fix copy-pasted class Javadoc. — DO-260B
  §A.3.3 Table A-36 / Table 2-13
- **LIB1090-033** *(improvement)* — `msgs/adsb/AirborneOperationalStatusV2Msg.java`:
  `getGeometricVerticalAccuracy()` now handles GVA encoding `3` — per the
  Table 2-71 Note, ADS-B V2 receivers treat it as `< 45 m` rather than fully
  unknown; Javadoc documents the 0/3 semantics. Raw encoding remains available
  via `getGVA()`. — DO-260B §2.2.3.2.7.2.8 Table 2-71, p.135

### Verification
- `mvn compile` passes.
- Only `LIB1090-026` (adds `case 7`) and `LIB1090-033` (adds GVA==3 branch)
  change runtime behavior; both are guarded to their single previously-unhandled
  encoding value and cited to the standard.

_Filed by the automated lib1090 standards audit._